### PR TITLE
Add CLI entry point for lemonade-stand

### DIFF
--- a/src/lemonade_stand/__init__.py
+++ b/src/lemonade_stand/__init__.py
@@ -4,6 +4,7 @@ from .comprehensive_recorder import ComprehensiveRecorder
 from .costs_tracker import CostsTracker
 from .responses_ai_player import ResponsesAIPlayer
 from .simple_game import SimpleLemonadeGame
+from .__main__ import main
 
 __version__ = "0.1.0"
 __all__ = [
@@ -11,4 +12,5 @@ __all__ = [
     "ResponsesAIPlayer",
     "ComprehensiveRecorder",
     "CostsTracker",
+    "main",
 ]

--- a/src/lemonade_stand/__main__.py
+++ b/src/lemonade_stand/__main__.py
@@ -1,0 +1,51 @@
+"""Command line interface for the lemonade stand benchmark."""
+
+from __future__ import annotations
+
+import argparse
+
+from .simple_game import SimpleLemonadeGame
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run a simple simulation of the lemonade stand game.
+
+    Parameters
+    ----------
+    argv:
+        Optional list of command line arguments. If ``None`` the arguments
+        are taken from ``sys.argv``.
+    """
+    parser = argparse.ArgumentParser(
+        description="Run a basic lemonade stand simulation"
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=30,
+        help="Number of days to play",
+    )
+    parser.add_argument(
+        "--price",
+        type=float,
+        help="Fixed price to charge each day (defaults to suggested starting price)",
+    )
+    args = parser.parse_args(argv)
+
+    game = SimpleLemonadeGame(days=args.days)
+    price = args.price if args.price is not None else game.suggested_starting_price
+
+    print(f"Starting game for {args.days} days at ${price:.2f} per lemonade\n")
+    for _ in range(args.days):
+        result = game.play_turn(price=price)
+        print(
+            f"Day {result['day']:2d}: price=${result['price']:.2f}"
+            f" customers={result['customers']:3d}"
+            f" profit=${result['profit']:.2f}"
+            f" cash=${result['cash']:.2f}"
+        )
+    print("Game over!")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()


### PR DESCRIPTION
## Summary
- provide a small CLI under `src/lemonade_stand/__main__.py`
- expose `main` in the package's `__init__`

## Testing
- `ruff check .` *(fails: blank line contains whitespace, I001)*
- `black --check src/lemonade_stand/__main__.py src/lemonade_stand/__init__.py`
- `mypy src/lemonade_stand/__main__.py src/lemonade_stand/__init__.py` *(fails: 30 errors in other modules)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866e3b44f748320b2a2cf4f4bbd69ad