### PR TITLE
Fix pytest import path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on the path so `src` package is discoverable
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))


### PR DESCRIPTION
## Summary
- ensure tests can import from `src` by inserting project root on `sys.path`

## Testing
- `pytest -q` *(fails: TestBusinessGame.test_turn_prompts)*

------
https://chatgpt.com/codex/tasks/task_e_686f6051395083209426398b2494ec12