### PR TITLE
Fix type hint for Any

### DIFF
--- a/src/lemonade_stand/business_game.py
+++ b/src/lemonade_stand/business_game.py
@@ -72,7 +72,7 @@ class Inventory:
 
         return sum(quantity for quantity, _ in self.items[item_type])
 
-    def get_inventory_details(self) -> Dict[str, List[Dict[str, any]]]:
+    def get_inventory_details(self) -> Dict[str, List[Dict[str, Any]]]:
         """Get detailed inventory information including expiration dates.
 
         Returns:
@@ -313,7 +313,7 @@ class DemandModel:
             hour for hour, mult in self.HOURLY_MULTIPLIERS.items() if mult >= threshold
         ]
 
-    def get_operating_hours_info(self) -> Dict[str, any]:
+    def get_operating_hours_info(self) -> Dict[str, Any]:
         """Get information about operating hours and demand patterns.
 
         Returns:


### PR DESCRIPTION
## Summary
- use `Any` in type annotations instead of `any`

## Testing
- `pip install -e .`
- `PYTHONPATH=. pytest -q` *(fails: TestBusinessGame.test_turn_prompts)*

------
https://chatgpt.com/codex/tasks/task_e_686fc9d5d0608320a31128f29ae7e744