### PR TITLE
Fix ruff B007 warnings in tests

### DIFF
--- a/tests/test_business_game.py
+++ b/tests/test_business_game.py
@@ -262,7 +262,7 @@ class TestBusinessGame:
         assert remaining_lemons > 40  # Should have most lemons left
 
         # Fast forward to day 7 (lemons still good)
-        for i in range(2, 8):
+        for _ in range(2, 8):
             game.start_new_day()
             game.set_price(10.0)  # Keep high price
             game.set_operating_hours(9, 10)
@@ -316,7 +316,7 @@ class TestBusinessGame:
         game = BusinessGame(seed=42)
 
         # Play a few days
-        for day in range(1, 4):
+        for _ in range(1, 4):
             game.start_new_day()
             game.order_supplies(cups=20, lemons=20, sugar=20, water=20)
             game.set_price(2.0)


### PR DESCRIPTION
## Summary
- rename unused loop variables in test suite

## Testing
- `uv run ruff check tests/test_business_game.py`
- `uv run python -m pytest -q` *(fails: TestBusinessGame.test_turn_prompts)*

------
https://chatgpt.com/codex/tasks/task_e_686fc9d6666083209dcbfd71f1a7bc2c