### PR TITLE
Fix inventory usage calc

### DIFF
--- a/src/lemonade_stand/comprehensive_recorder.py
+++ b/src/lemonade_stand/comprehensive_recorder.py
@@ -270,9 +270,9 @@ class MetricsAnalyzer:
         customers = game_result["total_customers"]
         return {
             "cups": customers,
-            "lemons": customers * 2,  # Assuming 2 lemons per cup
-            "sugar": customers * 20,  # 20g sugar per cup
-            "water": customers * 200,  # 200ml water per cup
+            "lemons": customers,
+            "sugar": customers,
+            "water": customers,
         }
 
     def _analyze_trend(self, game_result: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- update `_calculate_inventory_used` in `comprehensive_recorder.py`
- use one unit of each ingredient per customer

## Testing
- `uv run ruff check`
- `uv run ruff format src/lemonade_stand/comprehensive_recorder.py`
- `uv run python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870361f0958832084014310c42c581b