### PR TITLE
Restrict open_hour range

### DIFF
--- a/src/lemonade_stand/business_game.py
+++ b/src/lemonade_stand/business_game.py
@@ -488,17 +488,17 @@ class BusinessGame:
         """Set today's operating hours.
 
         Args:
-            open_hour: Opening hour (6-21)
+            open_hour: Opening hour (6-20)
             close_hour: Closing hour (6-21, must be > open_hour)
 
         Returns:
             Confirmation or error
         """
         # Validate hours
-        if open_hour < 6 or open_hour > 21:
+        if open_hour < 6 or open_hour > 20:
             return {
                 "success": False,
-                "error": f"Invalid open hour: {open_hour}. Must be between 6-21.",
+                "error": f"Invalid open hour: {open_hour}. Must be between 6-20.",
             }
 
         if close_hour < 6 or close_hour > 21:

--- a/src/lemonade_stand/openai_player.py
+++ b/src/lemonade_stand/openai_player.py
@@ -145,15 +145,15 @@ class AIPlayerV05:
         return {
             "type": "function",
             "name": "set_operating_hours",
-            "description": "Set today's operating hours (must be between 6-21)",
+            "description": "Set today's operating hours (open hour 6-20, close hour 6-21)",
             "parameters": {
                 "type": "object",
                 "properties": {
                     "open_hour": {
                         "type": "integer",
-                        "description": "Opening hour (6-21)",
+                        "description": "Opening hour (6-20)",
                         "minimum": 6,
-                        "maximum": 21,
+                        "maximum": 20,
                     },
                     "close_hour": {
                         "type": "integer",

--- a/tests/test_business_game.py
+++ b/tests/test_business_game.py
@@ -93,7 +93,7 @@ class TestBusinessGame:
         assert game.hours_set is True
 
         # Invalid hours
-        result = game.set_operating_hours(5, 17)  # Too early
+        result = game.set_operating_hours(21, 22)  # Too late for open
         assert result["success"] is False
         assert "Invalid open hour" in result["error"]
 


### PR DESCRIPTION
## Summary
- limit `set_operating_hours` so opening hour must be between 6 and 20
- update tool schema and docs in `openai_player`
- test new boundary case for invalid opening hour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870361e05a8832082d4811c0b4fd38e