### PR TITLE
Add return type annotations

### DIFF
--- a/src/lemonade_stand/business_game.py
+++ b/src/lemonade_stand/business_game.py
@@ -14,7 +14,7 @@ LEMONADE_RECIPE = {"cups": 1, "lemons": 1, "sugar": 1, "water": 1}
 class Inventory:
     """Manages perishable inventory with FIFO expiration tracking."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize empty inventory with shelf life definitions."""
         # Store items as deques of (quantity, expiry_day) tuples
         self.items: dict[str, deque[tuple[int, int]]] = {

--- a/src/lemonade_stand/game_recorder.py
+++ b/src/lemonade_stand/game_recorder.py
@@ -42,7 +42,7 @@ class GameRecorder:
         self.current_day_data = None
         self.current_attempt = 0
         
-    def start_day(self, day_number: int, game_state: dict[str, Any]):
+    def start_day(self, day_number: int, game_state: dict[str, Any]) -> None:
         """Start recording a new day.
         
         Args:
@@ -61,9 +61,14 @@ class GameRecorder:
             "start_time": datetime.now().isoformat(),
         }
         
-    def record_interaction(self, attempt: int, request: dict[str, Any], 
-                         response: Any, tool_executions: list[dict[str, Any]],
-                         duration_ms: int):
+    def record_interaction(
+        self,
+        attempt: int,
+        request: dict[str, Any],
+        response: Any,
+        tool_executions: list[dict[str, Any]],
+        duration_ms: int,
+    ) -> None:
         """Record a complete interaction (request/response/tools).
         
         Args:
@@ -162,7 +167,7 @@ class GameRecorder:
                 
         return data
         
-    def end_day(self, game_state_after: dict[str, Any], total_attempts: int):
+    def end_day(self, game_state_after: dict[str, Any], total_attempts: int) -> None:
         """Finish recording the current day.
         
         Args:
@@ -183,7 +188,7 @@ class GameRecorder:
         self.current_day = None
         self.current_day_data = None
         
-    def record_final_results(self, results: dict[str, Any], total_cost: float):
+    def record_final_results(self, results: dict[str, Any], total_cost: float) -> None:
         """Record final game results.
         
         Args:
@@ -234,7 +239,7 @@ class BenchmarkRecorder:
             "games": [],
         }
         
-    def add_game_recording(self, game_recorder: GameRecorder):
+    def add_game_recording(self, game_recorder: GameRecorder) -> None:
         """Add a completed game recording to the benchmark.
         
         Args:

--- a/src/lemonade_stand/openai_player.py
+++ b/src/lemonade_stand/openai_player.py
@@ -33,7 +33,7 @@ class OpenAIPlayer:
         self.include_reasoning_summary = include_reasoning_summary
 
         # For stateless approach - minimal tracking
-        self.reasoning_summaries = []
+        self.reasoning_summaries: list[dict[str, Any]] = []
 
         # Token tracking
         self.total_token_usage = {
@@ -63,7 +63,7 @@ class OpenAIPlayer:
         self.client = OpenAI(api_key=api_key)
 
         # Track errors
-        self.errors = []
+        self.errors: list[dict[str, Any]] = []
 
     def get_tools(self) -> list[dict[str, Any]]:
         """Define available tools for the AI."""
@@ -522,7 +522,7 @@ class OpenAIPlayer:
             "total_tokens": self.total_token_usage["total_tokens"],
         }
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset the player for a new game."""
         self.reasoning_summaries = []
         self.errors = []


### PR DESCRIPTION
## Summary
- add explicit return types to recorder methods
- type reasoning_summaries and errors collections
- annotate Inventory constructor

## Testing
- `mypy --strict src/lemonade_stand | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_687857d88d148320854622d7699bedbd