### PR TITLE
Fix unused datetime import

### DIFF
--- a/analysis/analyze_results.py
+++ b/analysis/analyze_results.py
@@ -4,9 +4,9 @@ import argparse
 import json
 import statistics
 import sys
-from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
+
 import matplotlib.pyplot as plt
 
 # Game constants


### PR DESCRIPTION
## Summary
- drop unused `datetime` and `Tuple` imports from `analysis/analyze_results.py`
- sort remaining imports

## Testing
- `ruff check analysis/analyze_results.py | grep -E '(F401|I001)' || echo 'no F401/I001'`

------
https://chatgpt.com/codex/tasks/task_e_687857d45a6c8320820910d254b6d74c