### PR TITLE
Handle optional openai dependency

### DIFF
--- a/src/lemonade_stand/__init__.py
+++ b/src/lemonade_stand/__init__.py
@@ -3,12 +3,13 @@
 # Version 0.5 - Business simulation with inventory management
 from .business_game import BusinessGame
 from .game_recorder import GameRecorder, BenchmarkRecorder
-from .openai_player import OpenAIPlayer
+try:
+    from .openai_player import OpenAIPlayer
+except ModuleNotFoundError:  # openai package not installed
+    OpenAIPlayer = None
 
 __version__ = "0.5.0"
-__all__ = [
-    "BusinessGame",
-    "OpenAIPlayer",
-    "GameRecorder",
-    "BenchmarkRecorder",
-]
+
+__all__ = ["BusinessGame", "GameRecorder", "BenchmarkRecorder"]
+if OpenAIPlayer is not None:
+    __all__.insert(1, "OpenAIPlayer")


### PR DESCRIPTION
## Summary
- make `OpenAIPlayer` optional in `src/lemonade_stand/__init__.py`
- keep main game classes available even when `openai` isn't installed

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687857d3417c8320b86c56ae3049c7a2