### PR TITLE
Add custom error classes and better OpenAI error handling

### DIFF
--- a/experiments/run_benchmark.py
+++ b/experiments/run_benchmark.py
@@ -17,7 +17,14 @@ sys.path.append(str(Path(__file__).parent.parent))
 # Load environment variables
 from dotenv import load_dotenv
 
-from src.lemonade_stand import OpenAIPlayer, BusinessGame, GameRecorder, BenchmarkRecorder
+from src.lemonade_stand import (
+    APICallError,
+    BenchmarkRecorder,
+    BusinessGame,
+    GameError,
+    GameRecorder,
+    OpenAIPlayer,
+)
 
 load_dotenv()
 
@@ -190,6 +197,20 @@ def run_single_game(
             "recorder": recorder,  # Include recorder for saving later
         }
 
+    except (GameError, APICallError) as e:
+        logger.error(f"Fatal error in game {game_number}: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return {
+            "game_number": game_number,
+            "model": model_name,
+            "success": False,
+            "starting_cash": starting_cash,
+            "error": str(e),
+            "days_played": game.current_day,
+            "duration_seconds": time.time() - start_time,
+        }
     except Exception as e:
         logger.error(f"Fatal error in game {game_number}: {e}")
         import traceback

--- a/src/lemonade_stand/__init__.py
+++ b/src/lemonade_stand/__init__.py
@@ -2,6 +2,7 @@
 
 # Version 0.5 - Business simulation with inventory management
 from .business_game import BusinessGame
+from .errors import APICallError, GameError
 from .game_recorder import BenchmarkRecorder, GameRecorder
 from .openai_player import OpenAIPlayer
 
@@ -11,4 +12,6 @@ __all__ = [
     "OpenAIPlayer",
     "GameRecorder",
     "BenchmarkRecorder",
+    "GameError",
+    "APICallError",
 ]

--- a/src/lemonade_stand/errors.py
+++ b/src/lemonade_stand/errors.py
@@ -1,0 +1,7 @@
+class GameError(Exception):
+    """Error raised when a game tool fails."""
+
+
+class APICallError(Exception):
+    """Error raised when an API call to OpenAI fails."""
+

--- a/tests/test_openai_player.py
+++ b/tests/test_openai_player.py
@@ -1,0 +1,40 @@
+import pytest
+from openai import OpenAIError
+
+from src.lemonade_stand import openai_player
+from src.lemonade_stand.business_game import BusinessGame
+from src.lemonade_stand.errors import APICallError, GameError
+from src.lemonade_stand.openai_player import OpenAIPlayer
+
+
+class DummyClient:
+    def __init__(self, *_, **__):
+        class _R:
+            @staticmethod
+            def create(**_kw):
+                return None
+
+        self.responses = _R()
+
+
+def test_execute_tool_unknown_tool(monkeypatch):
+    monkeypatch.setattr(openai_player, "OpenAI", DummyClient)
+    player = OpenAIPlayer(model_name="gpt-4.1-nano", api_key="dummy")
+    game = BusinessGame()
+    with pytest.raises(GameError):
+        player.execute_tool("unknown_tool", {}, game)
+
+
+def test_play_turn_api_error(monkeypatch):
+    monkeypatch.setattr(openai_player, "OpenAI", DummyClient)
+    player = OpenAIPlayer(model_name="gpt-4.1-nano", api_key="dummy")
+    game = BusinessGame()
+    game.start_new_day()
+
+    def fail(**kwargs):
+        raise OpenAIError("fail")
+
+    monkeypatch.setattr(player.client.responses, "create", fail)
+
+    with pytest.raises(APICallError):
+        player.play_turn(game)


### PR DESCRIPTION
## Summary
- create `GameError` and `APICallError`
- expose new exceptions from the package
- raise `GameError` from tool failures
- raise `APICallError` when the OpenAI client fails
- handle new exceptions in `run_benchmark`
- test new exception behaviour

## Testing
- `ruff check tests/test_openai_player.py src/lemonade_stand/openai_player.py experiments/run_benchmark.py src/lemonade_stand/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68785dc66b388320b8bf620ed0573729