### PR TITLE
Add OpenAI client cleanup

### DIFF
--- a/experiments/run_benchmark.py
+++ b/experiments/run_benchmark.py
@@ -206,6 +206,12 @@ def run_single_game(
             "duration_seconds": time.time() - start_time,
         }
 
+    finally:
+        try:
+            player.close()
+        except Exception as close_error:  # pragma: no cover - log but continue
+            logger.warning("Error closing player: %s", close_error)
+
 
 def aggregate_results(games: list[dict[str, Any]]) -> dict[str, Any]:
     """Aggregate results from multiple games.

--- a/src/lemonade_stand/openai_player.py
+++ b/src/lemonade_stand/openai_player.py
@@ -575,3 +575,11 @@ class OpenAIPlayer:
             "total_tokens": 0,
             "cached_input_tokens": 0,
         }
+
+    def close(self) -> None:
+        """Close the underlying OpenAI client if possible."""
+        if hasattr(self, "client") and hasattr(self.client, "close"):
+            try:
+                self.client.close()
+            except Exception as e:  # pragma: no cover - don't fail if close errors
+                logger.warning("Failed to close OpenAI client: %s", e)

--- a/tests/test_run_single_game.py
+++ b/tests/test_run_single_game.py
@@ -1,0 +1,25 @@
+import experiments.run_benchmark as rb
+
+class DummyPlayer:
+    def __init__(self, *args, **kwargs):
+        self.closed = False
+        DummyPlayer.instance = self
+        self.total_token_usage = {"total_tokens": 0}
+        self.reasoning_summaries = []
+        self.errors = []
+
+    def play_turn(self, game, recorder=None):
+        raise RuntimeError("boom")
+
+    def calculate_cost(self):
+        return {"total_cost": 0}
+
+    def close(self):
+        self.closed = True
+
+
+def test_close_called_on_exception(monkeypatch):
+    monkeypatch.setattr(rb, "OpenAIPlayer", DummyPlayer)
+    result = rb.run_single_game(model_name="test-model", game_number=1, days=1)
+    assert result["success"] is False
+    assert DummyPlayer.instance.closed is True


### PR DESCRIPTION
## Summary
- add `close()` method to `OpenAIPlayer`
- close the OpenAI client in `run_single_game`
- test that the cleanup runs when errors occur

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68785dc9a2a88320968e4e7fde052896