### PR TITLE
Use Decimal for monetary values

### DIFF
--- a/src/lemonade_stand/business_game.py
+++ b/src/lemonade_stand/business_game.py
@@ -2,11 +2,12 @@
 
 import random
 from collections import deque
+from decimal import Decimal
 from typing import Any
 
 # Game configuration constants
-DEFAULT_STARTING_CASH = 1000.0
-DEFAULT_HOURLY_OPERATING_COST = 5.0
+DEFAULT_STARTING_CASH = Decimal("1000.00")
+DEFAULT_HOURLY_OPERATING_COST = Decimal("5.00")
 DEFAULT_TOTAL_DAYS = 30
 LEMONADE_RECIPE = {"cups": 1, "lemons": 1, "sugar": 1, "water": 1}
 
@@ -33,11 +34,11 @@ class Inventory:
         }
 
         # Base costs for reference (actual costs vary daily)
-        self.base_costs: dict[str, float] = {
-            "cups": 0.05,
-            "lemons": 0.20,
-            "sugar": 0.10,
-            "water": 0.02,
+        self.base_costs: dict[str, Decimal] = {
+            "cups": Decimal("0.05"),
+            "lemons": Decimal("0.20"),
+            "sugar": Decimal("0.10"),
+            "water": Decimal("0.02"),
         }
 
     def add_items(self, item_type: str, quantity: int, current_day: int) -> None:
@@ -150,16 +151,16 @@ class Inventory:
 
         return expired
 
-    def get_total_value(self) -> float:
+    def get_total_value(self) -> Decimal:
         """Calculate total value of inventory at base costs.
 
         Returns:
             Total value in dollars
         """
-        total = 0.0
+        total = Decimal("0.00")
         for item_type in self.items:
             quantity = self.get_available(item_type)
-            total += quantity * self.base_costs[item_type]
+            total += Decimal(quantity) * self.base_costs[item_type]
         return total
 
     def can_make_lemonade(self) -> int:
@@ -321,8 +322,8 @@ class BusinessGame:
     def __init__(
         self,
         days: int = DEFAULT_TOTAL_DAYS,
-        starting_cash: float = DEFAULT_STARTING_CASH,
-        hourly_operating_cost: float = DEFAULT_HOURLY_OPERATING_COST,
+        starting_cash: Decimal = DEFAULT_STARTING_CASH,
+        hourly_operating_cost: Decimal = DEFAULT_HOURLY_OPERATING_COST,
         seed: int | None = None,
     ):
         """Initialize the business game.
@@ -335,9 +336,9 @@ class BusinessGame:
         """
         self.total_days = days
         self.current_day = 0
-        self.starting_cash = starting_cash
-        self.cash = starting_cash
-        self.hourly_operating_cost = hourly_operating_cost
+        self.starting_cash = Decimal(str(starting_cash))
+        self.cash = Decimal(str(starting_cash))
+        self.hourly_operating_cost = Decimal(str(hourly_operating_cost))
 
         # Initialize components
         self.inventory = Inventory()
@@ -351,19 +352,19 @@ class BusinessGame:
             self.rng = random.Random()
 
         # Daily state tracking
-        self.today_supply_costs: dict[str, float] = {}
+        self.today_supply_costs: dict[str, Decimal] = {}
         self.price_set = False
         self.hours_set = False
         self.open_hour: int | None = None
         self.close_hour: int | None = None
-        self.price: float | None = None
+        self.price: Decimal | None = None
 
         # History tracking
         self.history: list[dict[str, Any]] = []
-        self.supply_cost_history: list[dict[str, float]] = []
+        self.supply_cost_history: list[dict[str, Decimal]] = []
 
         # Yesterday's profit for display
-        self.yesterday_profit: float | None = None
+        self.yesterday_profit: Decimal | None = None
 
         # Recipe for making lemonade
         self.recipe = LEMONADE_RECIPE.copy()
@@ -382,8 +383,10 @@ class BusinessGame:
         # Generate today's supply costs (±10% variation)
         self.today_supply_costs = {}
         for item, base_cost in self.inventory.base_costs.items():
-            variation = self.rng.uniform(0.9, 1.1)
-            self.today_supply_costs[item] = round(base_cost * variation, 4)
+            variation = Decimal(str(self.rng.uniform(0.9, 1.1)))
+            self.today_supply_costs[item] = (base_cost * variation).quantize(
+                Decimal("0.0001")
+            )
 
         # Store in history
         self.supply_cost_history.append(
@@ -442,11 +445,12 @@ class BusinessGame:
 
         # Calculate total cost
         total_cost = (
-            cups * self.today_supply_costs["cups"]
-            + lemons * self.today_supply_costs["lemons"]
-            + sugar * self.today_supply_costs["sugar"]
-            + water * self.today_supply_costs["water"]
+            Decimal(cups) * self.today_supply_costs["cups"]
+            + Decimal(lemons) * self.today_supply_costs["lemons"]
+            + Decimal(sugar) * self.today_supply_costs["sugar"]
+            + Decimal(water) * self.today_supply_costs["water"]
         )
+        total_cost = total_cost.quantize(Decimal("0.01"))
 
         # Check if enough cash
         if total_cost > self.cash:
@@ -457,6 +461,7 @@ class BusinessGame:
 
         # Process order
         self.cash -= total_cost
+        self.cash = self.cash.quantize(Decimal("0.01"))
 
         # Add to inventory
         self.inventory.add_items("cups", cups, self.current_day)
@@ -523,7 +528,7 @@ class BusinessGame:
         if price < 0:
             return {"success": False, "error": "Price cannot be negative."}
 
-        self.price = round(price, 2)
+        self.price = Decimal(str(price)).quantize(Decimal("0.01"))
         self.price_set = True
 
         return {"success": True, "price": self.price}
@@ -575,7 +580,7 @@ class BusinessGame:
         assert self.open_hour is not None
         assert self.close_hour is not None
         hourly_customers = self.demand_model.calculate_daily_customers(
-            self.price,
+            float(self.price),
             self.open_hour,
             self.close_hour,
         )
@@ -613,13 +618,15 @@ class BusinessGame:
             total_customers_lost += lost
 
         # Calculate financials
-        revenue = total_customers_served * self.price
+        revenue = Decimal(total_customers_served) * self.price
         operating_hours = self.close_hour - self.open_hour
-        operating_cost = operating_hours * self.hourly_operating_cost
+        operating_cost = Decimal(operating_hours) * self.hourly_operating_cost
         profit = revenue - operating_cost
+        profit = profit.quantize(Decimal("0.01"))
 
         # Update cash
         self.cash += profit
+        self.cash = self.cash.quantize(Decimal("0.01"))
         self.yesterday_profit = profit
 
         # Create day result
@@ -644,7 +651,7 @@ class BusinessGame:
         # Return with success indicator
         return {"success": True, **day_result}
 
-    def get_historical_supply_costs(self) -> list[dict[str, float]]:
+    def get_historical_supply_costs(self) -> list[dict[str, Decimal]]:
         """Get historical supply cost data.
 
         Returns:
@@ -772,22 +779,25 @@ Today is Day {self.current_day}. You have ${self.cash:.2f} in cash. What would y
         Returns:
             Summary of game performance
         """
-        total_revenue = sum(day["revenue"] for day in self.history)
-        total_operating_cost = sum(day["operating_cost"] for day in self.history)
+        total_revenue = sum(Decimal(day["revenue"]) for day in self.history)
+        total_operating_cost = sum(
+            Decimal(day["operating_cost"]) for day in self.history
+        )
         total_customers = sum(day["customers_served"] for day in self.history)
         total_lost_sales = sum(day["customers_lost"] for day in self.history)
 
         return {
             "days_played": self.current_day,
             "final_cash": self.cash,
-            "total_profit": self.cash
-            - self.starting_cash,  # Profit over starting capital
+            "total_profit": self.cash - self.starting_cash,
             "total_revenue": total_revenue,
             "total_operating_cost": total_operating_cost,
             "total_customers": total_customers,
             "total_lost_sales": total_lost_sales,
-            "average_daily_profit": (self.cash - self.starting_cash) / self.current_day
-            if self.current_day > 0
-            else 0,
+            "average_daily_profit": (
+                (self.cash - self.starting_cash) / Decimal(self.current_day)
+                if self.current_day > 0
+                else Decimal("0.00")
+            ),
             "inventory_value": self.inventory.get_total_value(),
         }

--- a/src/lemonade_stand/game_recorder.py
+++ b/src/lemonade_stand/game_recorder.py
@@ -4,6 +4,14 @@ import json
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+from decimal import Decimal
+
+
+def _decimal_default(obj: Any) -> Any:
+    """JSON serializer for Decimal objects."""
+    if isinstance(obj, Decimal):
+        return float(obj)
+    raise TypeError(f"Type {type(obj)} not serializable")
 
 
 class GameRecorder:
@@ -199,7 +207,7 @@ class GameRecorder:
         self.current_day = None
         self.current_day_data = None
 
-    def record_final_results(self, results: dict[str, Any], total_cost: float) -> None:
+    def record_final_results(self, results: dict[str, Any], total_cost: Decimal) -> None:
         """Record final game results.
 
         Args:
@@ -207,7 +215,7 @@ class GameRecorder:
             total_cost: Total API cost for this game
         """
         self.game_data["final_results"] = results
-        self.game_data["total_cost"] = total_cost
+        self.game_data["total_cost"] = Decimal(str(total_cost))
         self.game_data["end_time"] = datetime.now().isoformat()
         self.game_data["duration_seconds"] = (
             datetime.now() - self.start_time
@@ -224,7 +232,7 @@ class GameRecorder:
             filepath: Path to save the JSON file
         """
         with open(filepath, "w") as f:
-            json.dump(self.game_data, f, indent=2)
+            json.dump(self.game_data, f, indent=2, default=_decimal_default)
 
 
 class BenchmarkRecorder:
@@ -277,4 +285,4 @@ class BenchmarkRecorder:
         """
         self.finalize()
         with open(filepath, "w") as f:
-            json.dump(self.benchmark_data, f, indent=2)
+            json.dump(self.benchmark_data, f, indent=2, default=_decimal_default)

--- a/tests/test_business_game.py
+++ b/tests/test_business_game.py
@@ -1,6 +1,7 @@
 """Tests for the business game engine."""
 
 
+from decimal import Decimal
 from src.lemonade_stand.business_game import BusinessGame
 
 
@@ -13,13 +14,13 @@ class TestBusinessGame:
 
         assert game.total_days == 100
         assert game.current_day == 0
-        assert game.cash == 100
-        assert game.hourly_operating_cost == 5
+        assert game.cash == Decimal("100")
+        assert game.hourly_operating_cost == Decimal("5")
         assert game.yesterday_profit is None
 
         # Test default starting cash and days
         default_game = BusinessGame()
-        assert default_game.cash == 1000
+        assert default_game.cash == Decimal("1000")
         assert default_game.total_days == 30
 
     def test_start_new_day(self):
@@ -31,13 +32,13 @@ class TestBusinessGame:
 
         assert game.current_day == 1
         assert day_info["day"] == 1
-        assert day_info["cash"] == 1000
+        assert day_info["cash"] == Decimal("1000")
         assert "expired_items" in day_info
 
         # Check supply costs were generated
         assert len(game.today_supply_costs) == 4
-        assert 0.04 <= game.today_supply_costs["cups"] <= 0.06  # 0.05 ± 10%
-        assert 0.18 <= game.today_supply_costs["lemons"] <= 0.22  # 0.20 ± 10%
+        assert Decimal("0.04") <= game.today_supply_costs["cups"] <= Decimal("0.06")
+        assert Decimal("0.18") <= game.today_supply_costs["lemons"] <= Decimal("0.22")
 
     def test_check_morning_prices(self):
         """Test checking morning prices."""
@@ -52,7 +53,7 @@ class TestBusinessGame:
         assert "lemons" in prices
         assert "sugar" in prices
         assert "water" in prices
-        assert all(isinstance(p, float) for p in prices.values())
+        assert all(isinstance(p, Decimal) for p in prices.values())
 
     def test_order_supplies_success(self):
         """Test ordering supplies with sufficient funds."""
@@ -63,7 +64,7 @@ class TestBusinessGame:
         result = game.order_supplies(cups=100, lemons=50, sugar=50, water=100)
 
         assert result["success"] is True
-        assert result["remaining_cash"] < 1000  # Cash decreased
+        assert result["remaining_cash"] < Decimal("1000")  # Cash decreased
         assert game.inventory.get_available("cups") == 100
         assert game.inventory.get_available("lemons") == 50
 
@@ -77,7 +78,7 @@ class TestBusinessGame:
 
         assert result["success"] is False
         assert "Insufficient funds" in result["error"]
-        assert game.cash == 10  # Cash unchanged
+        assert game.cash == Decimal("10")  # Cash unchanged
         assert game.inventory.get_available("cups") == 0  # No items added
 
     def test_set_operating_hours(self):
@@ -111,7 +112,7 @@ class TestBusinessGame:
         # Valid price
         result = game.set_price(2.50)
         assert result["success"] is True
-        assert game.price == 2.50
+        assert game.price == Decimal("2.50")
         assert game.price_set is True
 
         # Negative price
@@ -151,10 +152,10 @@ class TestBusinessGame:
         result = game.simulate_day()
 
         assert result["day"] == 1
-        assert result["price"] == 2.0
+        assert result["price"] == Decimal("2.0")
         assert result["hours_open"] == 4
         assert result["customers_served"] >= 0
-        assert result["operating_cost"] == 20  # 4 hours * $5
+        assert result["operating_cost"] == Decimal("20")  # 4 hours * $5
         assert "profit" in result
         assert "hourly_sales" in result
 
@@ -199,7 +200,7 @@ class TestBusinessGame:
         # Check history
         assert len(game.history) == 1
         assert game.history[0]["day"] == 1
-        assert game.history[0]["price"] == 2.5
+        assert game.history[0]["price"] == Decimal("2.5")
         assert game.history[0]["open_hour"] == 9
         assert game.history[0]["close_hour"] == 17
         assert "customers_served" in game.history[0]
@@ -332,7 +333,7 @@ class TestBusinessGame:
 
         assert results["days_played"] == 3
         assert results["final_cash"] == game.cash
-        assert results["total_profit"] == game.cash - 1000
+        assert results["total_profit"] == game.cash - Decimal("1000")
         assert results["total_customers"] >= 0
         assert "average_daily_profit" in results
         assert "inventory_value" in results

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -189,4 +189,4 @@ class TestInventory:
         inv.add_items("sugar", 75, current_day=1)  # 75 * 0.10 = 7.50
         inv.add_items("water", 200, current_day=1)  # 200 * 0.02 = 4.00
 
-        assert inv.get_total_value() == pytest.approx(26.50)
+        assert float(inv.get_total_value()) == pytest.approx(26.50)


### PR DESCRIPTION
## Summary
- switch currency fields in BusinessGame to `decimal.Decimal`
- ensure recordings serialize Decimal values properly
- update tests to expect Decimal types

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68785dcc679c83209ee98dc77621bdc9