### PR TITLE
Add progress bars for benchmark loops

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "matplotlib>=3.5.0",
     "requests>=2.28.0",
     "tiktoken>=0.9.0",
+    "tqdm>=4.67.1",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -488,6 +488,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "requests" },
     { name = "tiktoken" },
+    { name = "tqdm" },
 ]
 
 [package.optional-dependencies]
@@ -519,6 +520,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.28.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "tiktoken", specifier = ">=0.9.0" },
+    { name = "tqdm", specifier = ">=4.67.1" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
## Summary
- add tqdm dependency
- show progress for game days, games, and models

## Testing
- `uv run ruff check | head`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68785dd536748320b739e51f7189f2d1