### PR TITLE
Add OpenAI client cleanup

### DIFF
--- a/experiments/run_benchmark.py
+++ b/experiments/run_benchmark.py
@@ -205,6 +205,8 @@ def run_single_game(
             "days_played": game.current_day,
             "duration_seconds": time.time() - start_time,
         }
+    finally:
+        player.close()
 
 
 def aggregate_results(games: list[dict[str, Any]]) -> dict[str, Any]:

--- a/src/lemonade_stand/openai_player.py
+++ b/src/lemonade_stand/openai_player.py
@@ -62,6 +62,22 @@ class OpenAIPlayer:
             raise ValueError("OpenAI API key not found")
         self.client = OpenAI(api_key=api_key)
 
+    def close(self) -> None:
+        """Close the underlying OpenAI client."""
+        try:
+            close_method = getattr(self.client, "close", None)
+            if callable(close_method):
+                close_method()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(f"Failed to close OpenAI client: {exc}")
+
+    # Support use as a context manager
+    def __enter__(self) -> "OpenAIPlayer":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - trivial
+        self.close()
+
         # Track errors
         self.errors: list[dict[str, Any]] = []
 


### PR DESCRIPTION
## Summary
- support context manager/close API in OpenAIPlayer
- ensure OpenAI client is closed in run_benchmark

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68785dd8278c8320977d26d8ccffee4d