### PR TITLE
Switch monetary values to Decimal

### DIFF
--- a/src/lemonade_stand/business_game.py
+++ b/src/lemonade_stand/business_game.py
@@ -2,11 +2,14 @@
 
 import random
 from collections import deque
+from decimal import Decimal
 from typing import Any
 
+from .utils import to_decimal
+
 # Game configuration constants
-DEFAULT_STARTING_CASH = 1000.0
-DEFAULT_HOURLY_OPERATING_COST = 5.0
+DEFAULT_STARTING_CASH = Decimal("1000")
+DEFAULT_HOURLY_OPERATING_COST = Decimal("5")
 DEFAULT_TOTAL_DAYS = 30
 LEMONADE_RECIPE = {"cups": 1, "lemons": 1, "sugar": 1, "water": 1}
 
@@ -33,11 +36,11 @@ class Inventory:
         }
 
         # Base costs for reference (actual costs vary daily)
-        self.base_costs: dict[str, float] = {
-            "cups": 0.05,
-            "lemons": 0.20,
-            "sugar": 0.10,
-            "water": 0.02,
+        self.base_costs: dict[str, Decimal] = {
+            "cups": Decimal("0.05"),
+            "lemons": Decimal("0.20"),
+            "sugar": Decimal("0.10"),
+            "water": Decimal("0.02"),
         }
 
     def add_items(self, item_type: str, quantity: int, current_day: int) -> None:
@@ -150,16 +153,16 @@ class Inventory:
 
         return expired
 
-    def get_total_value(self) -> float:
+    def get_total_value(self) -> Decimal:
         """Calculate total value of inventory at base costs.
 
         Returns:
             Total value in dollars
         """
-        total = 0.0
+        total = Decimal("0")
         for item_type in self.items:
             quantity = self.get_available(item_type)
-            total += quantity * self.base_costs[item_type]
+            total += to_decimal(quantity) * self.base_costs[item_type]
         return total
 
     def can_make_lemonade(self) -> int:
@@ -321,8 +324,8 @@ class BusinessGame:
     def __init__(
         self,
         days: int = DEFAULT_TOTAL_DAYS,
-        starting_cash: float = DEFAULT_STARTING_CASH,
-        hourly_operating_cost: float = DEFAULT_HOURLY_OPERATING_COST,
+        starting_cash: Decimal | float = DEFAULT_STARTING_CASH,
+        hourly_operating_cost: Decimal | float = DEFAULT_HOURLY_OPERATING_COST,
         seed: int | None = None,
     ):
         """Initialize the business game.
@@ -335,9 +338,9 @@ class BusinessGame:
         """
         self.total_days = days
         self.current_day = 0
-        self.starting_cash = starting_cash
-        self.cash = starting_cash
-        self.hourly_operating_cost = hourly_operating_cost
+        self.starting_cash = to_decimal(starting_cash)
+        self.cash = to_decimal(starting_cash)
+        self.hourly_operating_cost = to_decimal(hourly_operating_cost)
 
         # Initialize components
         self.inventory = Inventory()
@@ -351,19 +354,19 @@ class BusinessGame:
             self.rng = random.Random()
 
         # Daily state tracking
-        self.today_supply_costs: dict[str, float] = {}
+        self.today_supply_costs: dict[str, Decimal] = {}
         self.price_set = False
         self.hours_set = False
         self.open_hour: int | None = None
         self.close_hour: int | None = None
-        self.price: float | None = None
+        self.price: Decimal | None = None
 
         # History tracking
         self.history: list[dict[str, Any]] = []
-        self.supply_cost_history: list[dict[str, float]] = []
+        self.supply_cost_history: list[dict[str, Decimal]] = []
 
         # Yesterday's profit for display
-        self.yesterday_profit: float | None = None
+        self.yesterday_profit: Decimal | None = None
 
         # Recipe for making lemonade
         self.recipe = LEMONADE_RECIPE.copy()
@@ -382,8 +385,8 @@ class BusinessGame:
         # Generate today's supply costs (±10% variation)
         self.today_supply_costs = {}
         for item, base_cost in self.inventory.base_costs.items():
-            variation = self.rng.uniform(0.9, 1.1)
-            self.today_supply_costs[item] = round(base_cost * variation, 4)
+            variation = Decimal(str(self.rng.uniform(0.9, 1.1)))
+            self.today_supply_costs[item] = (base_cost * variation).quantize(Decimal("0.0001"))
 
         # Store in history
         self.supply_cost_history.append(
@@ -442,10 +445,10 @@ class BusinessGame:
 
         # Calculate total cost
         total_cost = (
-            cups * self.today_supply_costs["cups"]
-            + lemons * self.today_supply_costs["lemons"]
-            + sugar * self.today_supply_costs["sugar"]
-            + water * self.today_supply_costs["water"]
+            to_decimal(cups) * self.today_supply_costs["cups"]
+            + to_decimal(lemons) * self.today_supply_costs["lemons"]
+            + to_decimal(sugar) * self.today_supply_costs["sugar"]
+            + to_decimal(water) * self.today_supply_costs["water"]
         )
 
         # Check if enough cash
@@ -523,7 +526,7 @@ class BusinessGame:
         if price < 0:
             return {"success": False, "error": "Price cannot be negative."}
 
-        self.price = round(price, 2)
+        self.price = to_decimal(round(price, 2))
         self.price_set = True
 
         return {"success": True, "price": self.price}
@@ -575,7 +578,7 @@ class BusinessGame:
         assert self.open_hour is not None
         assert self.close_hour is not None
         hourly_customers = self.demand_model.calculate_daily_customers(
-            self.price,
+            float(self.price),
             self.open_hour,
             self.close_hour,
         )
@@ -613,8 +616,8 @@ class BusinessGame:
             total_customers_lost += lost
 
         # Calculate financials
-        revenue = total_customers_served * self.price
-        operating_hours = self.close_hour - self.open_hour
+        revenue = to_decimal(total_customers_served) * self.price
+        operating_hours = Decimal(self.close_hour - self.open_hour)
         operating_cost = operating_hours * self.hourly_operating_cost
         profit = revenue - operating_cost
 
@@ -644,7 +647,7 @@ class BusinessGame:
         # Return with success indicator
         return {"success": True, **day_result}
 
-    def get_historical_supply_costs(self) -> list[dict[str, float]]:
+    def get_historical_supply_costs(self) -> list[dict[str, Decimal]]:
         """Get historical supply cost data.
 
         Returns:
@@ -772,8 +775,10 @@ Today is Day {self.current_day}. You have ${self.cash:.2f} in cash. What would y
         Returns:
             Summary of game performance
         """
-        total_revenue = sum(day["revenue"] for day in self.history)
-        total_operating_cost = sum(day["operating_cost"] for day in self.history)
+        total_revenue = sum((day["revenue"] for day in self.history), Decimal("0"))
+        total_operating_cost = sum(
+            (day["operating_cost"] for day in self.history), Decimal("0")
+        )
         total_customers = sum(day["customers_served"] for day in self.history)
         total_lost_sales = sum(day["customers_lost"] for day in self.history)
 
@@ -786,8 +791,8 @@ Today is Day {self.current_day}. You have ${self.cash:.2f} in cash. What would y
             "total_operating_cost": total_operating_cost,
             "total_customers": total_customers,
             "total_lost_sales": total_lost_sales,
-            "average_daily_profit": (self.cash - self.starting_cash) / self.current_day
+            "average_daily_profit": (self.cash - self.starting_cash) / to_decimal(self.current_day)
             if self.current_day > 0
-            else 0,
+            else Decimal("0"),
             "inventory_value": self.inventory.get_total_value(),
         }

--- a/src/lemonade_stand/game_recorder.py
+++ b/src/lemonade_stand/game_recorder.py
@@ -224,7 +224,7 @@ class GameRecorder:
             filepath: Path to save the JSON file
         """
         with open(filepath, "w") as f:
-            json.dump(self.game_data, f, indent=2)
+            json.dump(self.game_data, f, indent=2, default=str)
 
 
 class BenchmarkRecorder:
@@ -277,4 +277,4 @@ class BenchmarkRecorder:
         """
         self.finalize()
         with open(filepath, "w") as f:
-            json.dump(self.benchmark_data, f, indent=2)
+            json.dump(self.benchmark_data, f, indent=2, default=str)

--- a/src/lemonade_stand/openai_player.py
+++ b/src/lemonade_stand/openai_player.py
@@ -247,9 +247,9 @@ class OpenAIPlayer:
             else:
                 result = {"error": f"Unknown tool: {tool_name}"}
 
-            return json.dumps(result)
+            return json.dumps(result, default=str)
         except Exception as e:
-            return json.dumps({"error": str(e)})
+            return json.dumps({"error": str(e)}, default=str)
 
     def play_turn(
         self, game: BusinessGame, recorder: GameRecorder | None = None

--- a/src/lemonade_stand/utils.py
+++ b/src/lemonade_stand/utils.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from decimal import Decimal, getcontext
+
+# Set global precision for all Decimal operations
+getcontext().prec = 28
+
+
+def to_decimal(value: int | float | str | Decimal) -> Decimal:
+    """Convert various numeric types to ``Decimal`` safely."""
+    return Decimal(str(value))

--- a/tests/test_business_game.py
+++ b/tests/test_business_game.py
@@ -1,6 +1,8 @@
 """Tests for the business game engine."""
 
 
+from decimal import Decimal
+
 from src.lemonade_stand.business_game import BusinessGame
 
 
@@ -9,17 +11,17 @@ class TestBusinessGame:
 
     def test_init(self):
         """Test game initialization."""
-        game = BusinessGame(days=100, starting_cash=100, seed=42)
+        game = BusinessGame(days=100, starting_cash=Decimal("100"), seed=42)
 
         assert game.total_days == 100
         assert game.current_day == 0
-        assert game.cash == 100
-        assert game.hourly_operating_cost == 5
+        assert game.cash == Decimal("100")
+        assert game.hourly_operating_cost == Decimal("5")
         assert game.yesterday_profit is None
 
         # Test default starting cash and days
         default_game = BusinessGame()
-        assert default_game.cash == 1000
+        assert default_game.cash == Decimal("1000")
         assert default_game.total_days == 30
 
     def test_start_new_day(self):
@@ -31,13 +33,13 @@ class TestBusinessGame:
 
         assert game.current_day == 1
         assert day_info["day"] == 1
-        assert day_info["cash"] == 1000
+        assert day_info["cash"] == Decimal("1000")
         assert "expired_items" in day_info
 
         # Check supply costs were generated
         assert len(game.today_supply_costs) == 4
-        assert 0.04 <= game.today_supply_costs["cups"] <= 0.06  # 0.05 ± 10%
-        assert 0.18 <= game.today_supply_costs["lemons"] <= 0.22  # 0.20 ± 10%
+        assert Decimal("0.04") <= game.today_supply_costs["cups"] <= Decimal("0.06")
+        assert Decimal("0.18") <= game.today_supply_costs["lemons"] <= Decimal("0.22")
 
     def test_check_morning_prices(self):
         """Test checking morning prices."""
@@ -52,7 +54,7 @@ class TestBusinessGame:
         assert "lemons" in prices
         assert "sugar" in prices
         assert "water" in prices
-        assert all(isinstance(p, float) for p in prices.values())
+        assert all(isinstance(p, Decimal) for p in prices.values())
 
     def test_order_supplies_success(self):
         """Test ordering supplies with sufficient funds."""
@@ -63,7 +65,7 @@ class TestBusinessGame:
         result = game.order_supplies(cups=100, lemons=50, sugar=50, water=100)
 
         assert result["success"] is True
-        assert result["remaining_cash"] < 1000  # Cash decreased
+        assert result["remaining_cash"] < Decimal("1000")  # Cash decreased
         assert game.inventory.get_available("cups") == 100
         assert game.inventory.get_available("lemons") == 50
 
@@ -77,7 +79,7 @@ class TestBusinessGame:
 
         assert result["success"] is False
         assert "Insufficient funds" in result["error"]
-        assert game.cash == 10  # Cash unchanged
+        assert game.cash == Decimal("10")  # Cash unchanged
         assert game.inventory.get_available("cups") == 0  # No items added
 
     def test_set_operating_hours(self):
@@ -111,7 +113,7 @@ class TestBusinessGame:
         # Valid price
         result = game.set_price(2.50)
         assert result["success"] is True
-        assert game.price == 2.50
+        assert game.price == Decimal("2.50")
         assert game.price_set is True
 
         # Negative price
@@ -151,10 +153,10 @@ class TestBusinessGame:
         result = game.simulate_day()
 
         assert result["day"] == 1
-        assert result["price"] == 2.0
+        assert result["price"] == Decimal("2.0")
         assert result["hours_open"] == 4
         assert result["customers_served"] >= 0
-        assert result["operating_cost"] == 20  # 4 hours * $5
+        assert result["operating_cost"] == Decimal("20")  # 4 hours * $5
         assert "profit" in result
         assert "hourly_sales" in result
 
@@ -199,7 +201,7 @@ class TestBusinessGame:
         # Check history
         assert len(game.history) == 1
         assert game.history[0]["day"] == 1
-        assert game.history[0]["price"] == 2.5
+        assert game.history[0]["price"] == Decimal("2.5")
         assert game.history[0]["open_hour"] == 9
         assert game.history[0]["close_hour"] == 17
         assert "customers_served" in game.history[0]
@@ -332,7 +334,7 @@ class TestBusinessGame:
 
         assert results["days_played"] == 3
         assert results["final_cash"] == game.cash
-        assert results["total_profit"] == game.cash - 1000
+        assert results["total_profit"] == game.cash - Decimal("1000")
         assert results["total_customers"] >= 0
         assert "average_daily_profit" in results
         assert "inventory_value" in results

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,5 +1,7 @@
 """Tests for the inventory management system."""
 
+from decimal import Decimal
+
 import pytest
 
 from src.lemonade_stand.business_game import Inventory
@@ -189,4 +191,4 @@ class TestInventory:
         inv.add_items("sugar", 75, current_day=1)  # 75 * 0.10 = 7.50
         inv.add_items("water", 200, current_day=1)  # 200 * 0.02 = 4.00
 
-        assert inv.get_total_value() == pytest.approx(26.50)
+        assert inv.get_total_value() == pytest.approx(Decimal("26.50"))


### PR DESCRIPTION
## Summary
- add Decimal helpers in `utils`
- migrate BusinessGame and Inventory costs to `Decimal`
- handle Decimal conversion in recorder and player
- update tests for Decimal values

## Testing
- `ruff check src/lemonade_stand/business_game.py src/lemonade_stand/game_recorder.py src/lemonade_stand/openai_player.py tests/test_business_game.py tests/test_inventory.py src/lemonade_stand/utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68785dd99d048320964737c0610bb776