### PR TITLE
Add client close support and safe shutdown

### DIFF
--- a/experiments/run_benchmark.py
+++ b/experiments/run_benchmark.py
@@ -205,6 +205,8 @@ def run_single_game(
             "days_played": game.current_day,
             "duration_seconds": time.time() - start_time,
         }
+    finally:
+        player.close()
 
 
 def aggregate_results(games: list[dict[str, Any]]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- store `api_key` on `OpenAIPlayer` and expose `close()` to shut down client
- reinitialize OpenAI client in `reset()` after closing previous one
- ensure `run_single_game` always closes the client with a `finally` block

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68785dfc87b8832093b3b4f266fe8509