### PR TITLE
Add parallel game execution

### DIFF
--- a/src/lemonade_stand/game_recorder.py
+++ b/src/lemonade_stand/game_recorder.py
@@ -250,13 +250,16 @@ class BenchmarkRecorder:
             "games": [],
         }
 
-    def add_game_recording(self, game_recorder: GameRecorder) -> None:
+    def add_game_recording(self, game_record: GameRecorder | dict[str, Any]) -> None:
         """Add a completed game recording to the benchmark.
 
         Args:
-            game_recorder: Completed GameRecorder instance
+            game_record: Completed ``GameRecorder`` instance or raw game data
         """
-        self.benchmark_data["games"].append(game_recorder.get_recording())
+        if isinstance(game_record, GameRecorder):
+            self.benchmark_data["games"].append(game_record.get_recording())
+        else:
+            self.benchmark_data["games"].append(game_record)
 
     def finalize(self) -> dict[str, Any]:
         """Finalize the benchmark recording."""


### PR DESCRIPTION
## Summary
- run games concurrently using `ProcessPoolExecutor`
- record each game's data to a unique file so results can be merged later
- allow configuring worker processes via `--workers`
- support passing raw game data into `BenchmarkRecorder`

## Testing
- `uv run ruff check` *(fails: Import block is un-sorted)*
- `uv run ruff format`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68785df96f2c83208ae9ca49a85ff56e