### PR TITLE
Refactor error handling for business game

### DIFF
--- a/src/lemonade_stand/__init__.py
+++ b/src/lemonade_stand/__init__.py
@@ -4,6 +4,7 @@
 from .business_game import BusinessGame
 from .game_recorder import BenchmarkRecorder, GameRecorder
 from .openai_player import OpenAIPlayer
+from .types import GameError, Result
 
 __version__ = "0.5.0"
 __all__ = [
@@ -11,4 +12,6 @@ __all__ = [
     "OpenAIPlayer",
     "GameRecorder",
     "BenchmarkRecorder",
+    "GameError",
+    "Result",
 ]

--- a/src/lemonade_stand/openai_player.py
+++ b/src/lemonade_stand/openai_player.py
@@ -8,8 +8,11 @@ from typing import Any
 
 from openai import OpenAI
 
+from dataclasses import asdict
+
 from .business_game import BusinessGame
 from .game_recorder import GameRecorder
+from .types import GameError, Result
 
 logger = logging.getLogger(__name__)
 
@@ -247,7 +250,11 @@ class OpenAIPlayer:
             else:
                 result = {"error": f"Unknown tool: {tool_name}"}
 
+            if isinstance(result, Result):
+                return json.dumps(result.asdict())
             return json.dumps(result)
+        except GameError as ge:
+            return json.dumps(ge.asdict())
         except Exception as e:
             return json.dumps({"error": str(e)})
 

--- a/src/lemonade_stand/types.py
+++ b/src/lemonade_stand/types.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+
+@dataclass
+class Result:
+    """Standard success result from game operations."""
+
+    data: Dict[str, Any] = field(default_factory=dict)
+    success: bool = True
+
+    def asdict(self) -> Dict[str, Any]:
+        return {"success": self.success, **self.data}
+
+
+@dataclass
+class GameError(Exception):
+    """Exception raised for invalid game operations."""
+
+    message: str
+    data: Dict[str, Any] | None = None
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.message
+
+    def asdict(self) -> Dict[str, Any]:
+        result = {"success": False, "error": self.message}
+        if self.data:
+            result.update(self.data)
+        return result


### PR DESCRIPTION
## Summary
- add `GameError` and `Result` dataclasses
- raise `GameError` and return `Result` objects from business game actions
- adapt OpenAI player to handle new result types
- update business game tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68785df45aec8320994d955fab429dd6