### PR TITLE
v1: persist has_automation + edge-case tests

### DIFF
--- a/lemonade_bench_v1/experiments/run_benchmark.py
+++ b/lemonade_bench_v1/experiments/run_benchmark.py
@@ -129,6 +129,7 @@ def run_single_game(
                     "inventory": game.check_inventory(),
                     "expired_items": day_info["expired_items"],
                     "supply_costs": supply_costs,
+                    "has_automation": game.has_automation,
                 },
             )
 
@@ -169,6 +170,7 @@ def run_single_game(
                     "price": game.price,
                     "open_hour": game.open_hour,
                     "close_hour": game.close_hour,
+                    "has_automation": game.has_automation,
                 },
                 total_attempts=turn_result.get("attempts", 1),
             )

--- a/lemonade_bench_v1/tests/test_business_game.py
+++ b/lemonade_bench_v1/tests/test_business_game.py
@@ -290,6 +290,10 @@ class TestBusinessGame:
         assert "You run a lemonade stand" in system_prompt
         assert "100 days" in system_prompt
         assert "purchase_automation" in system_prompt
+        # Pin the cost numbers so any constant change must update the prompt
+        assert "$3.00 labor" in system_prompt
+        assert "$2.00 utilities" in system_prompt
+        assert "$1000.00" in system_prompt
 
         # Start day 1
         game.start_new_day()
@@ -348,6 +352,14 @@ class TestBusinessGame:
         assert result["success"] is False
         assert "already" in result["error"].lower()
         assert game.cash == cash_after_first
+
+    def test_purchase_automation_exact_cash(self):
+        """Buying automation with exactly the right cash succeeds, leaves $0."""
+        game = BusinessGame(starting_cash=Decimal(1000))
+        result = game.purchase_automation()
+        assert result["success"] is True
+        assert game.has_automation is True
+        assert game.cash == Decimal(0)
 
     def test_purchase_automation_insufficient_cash(self):
         """Without enough cash, purchase fails and state is unchanged."""


### PR DESCRIPTION
Follow-up to #75 from /review.

## Summary
- Record \`has_automation\` in both \`start_day\` and \`end_day\` game state so JSON recordings have direct evidence of when automation kicked in.
- New test: \`starting_cash == automation_cost\` edge case (succeeds, leaves \$0).
- Prompt assertions: pin \"\$3.00 labor\", \"\$2.00 utilities\", \"\$1000.00\" in system prompt so future constant changes can't silently desync prompt vs. logic.

## Test plan
- [x] 42/42 pytest pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)