### PR TITLE
v1: add purchase_advertising tool with same-day aggregation

### DIFF
--- a/lemonade_bench_v1/MECHANICS.md
+++ b/lemonade_bench_v1/MECHANICS.md
@@ -1,0 +1,160 @@
+# LemonadeBench v1 — Game Mechanics
+
+## Game length and starting state
+
+- **Default horizon**: 100 days (was 30 in v0.5)
+- **Starting cash**: $1,000
+- **Starting inventory**: 0 of each ingredient
+- **Game over**: cash < 0 (bankrupt) or day count exhausted
+
+## Daily decisions
+
+Each day the model makes the following decisions, in any order, before opening the stand:
+1. Order supplies (cups, lemons, sugar, water)
+2. Set price per lemonade
+3. Set operating hours
+4. Optionally purchase automation
+5. Call `open_for_business()` to commit
+
+Then the simulator runs the day's sales, and the model sees the results next morning.
+
+## Demand
+
+Customer demand per hour:
+$$Q(p, h) = (50 - 10p) \cdot m_h \cdot \epsilon_h$$
+
+- $p$ = price per cup
+- $m_h$ = hourly multiplier (foot traffic curve)
+- $\epsilon_h \sim U(0.9, 1.1)$ = independent ±10% noise per hour
+
+If $50 - 10p \le 0$ (price ≥ $5), demand is zero.
+
+### Hourly multipliers
+
+| Hour | $m_h$ | Hour | $m_h$ | Hour | $m_h$ |
+|---|---:|---|---:|---|---:|
+| 6 AM | 0.3 | 11 AM | 1.2 | 4 PM | 0.9 |
+| 7 AM | 0.5 | 12 PM | 1.5 | 5 PM | 1.1 |
+| 8 AM | 0.7 | 1 PM | 1.3 | 6 PM | 1.0 |
+| 9 AM | 0.8 | 2 PM | 0.9 | 7 PM | 0.7 |
+| 10 AM | 1.0 | 3 PM | 0.8 | 8 PM | 0.4 |
+
+Sum across all 15 hours (6 AM–8 PM): $\sum m_h = 13.1$. Hours outside 6 AM–8 PM have $m_h = 0$.
+
+## Ingredients (recipe + economics)
+
+One cup of lemonade requires **all four** ingredients in stock:
+
+| Item | Base cost | Shelf life |
+|---|---:|---:|
+| Cup | $0.05 | 30 days |
+| Lemon | $0.20 | 7 days |
+| Sugar | $0.10 | 60 days |
+| Water | $0.02 | never |
+| **Total per cup** | **$0.37** | |
+
+- Daily prices vary ±10% around base.
+- Inventory uses **FIFO** — oldest items consumed first.
+- Items purchased on day $N$ with shelf life $S$ expire on the morning of day $N + S$.
+- Expired items are discarded automatically each morning.
+- Supplies are delivered instantly when ordered.
+
+## Operating costs
+
+Per hour the stand is open:
+
+| Component | Cost | Eliminated by |
+|---|---:|---|
+| Labor | $3.00/hr | automation |
+| Utilities | $2.00/hr | — |
+| **Total (default)** | **$5.00/hr** | |
+
+## Automation (added v1.0)
+
+- One-time purchase: **$1,000**
+- Effect: labor drops to $0/hr permanently
+- Same-day effect (today's hours bill at the new rate)
+- Can only be purchased once
+- Rejects if `cash < 1000`
+- Utilities ($2/hr) continue regardless
+
+Payback at full operation: $1,000 ÷ ($3 × 15 hrs) ≈ 22 days.
+
+## Theoretical optimal (no automation)
+
+Max profit per cup:
+$$\pi(p) = (50 - 10p)(p - 0.37)$$
+$$p^* = \$2.69 \quad Q(p^*) = 23.1 \text{ cust/hr}$$
+
+Daily profit at optimal:
+$$\pi_{\text{day}} = 53.59 \times 13.1 - 5 \times 15 = \$702.03 - \$75 = \$627.03$$
+
+100-day theoretical max (no automation): **$62,703**.
+
+With automation purchased on day 1: same daily revenue, operating cost drops from $75 to $30 → +$45/day × 100 days = +$4,500. Less the $1,000 cost = **net +$3,500** over no-automation baseline. New theoretical max: **~$66,200**.
+
+## Advertising
+
+A `purchase_advertising(spend)` tool that lets the model spend cash on ads, boosting demand for the following days with diminishing returns and noisy outcomes.
+
+### Mechanic
+
+1. **Spend → goodwill**: each campaign adds to a hidden "advertising goodwill" stock:
+   $$\Delta \text{goodwill} = \sqrt{\text{spend}/100} \cdot s \cdot u, \quad u \sim U(0.9, 1.1)$$
+   where $s$ is `sqrt_scale` (parameter, currently 10).
+2. **Goodwill → demand multiplier** each day:
+   $$\text{multiplier} = 1 + c \cdot (1 - e^{-\text{goodwill}})$$
+   where $c$ is `mult_cap` — the maximum boost. Saturates at $1+c$ no matter how much goodwill accumulates.
+3. **Daily decay**: each morning, $\text{goodwill} \mathrel{*}= 0.80$ (20% bleeds off).
+4. **Effect on demand**: that day's customer counts (after the existing per-hour noise) are scaled by the multiplier.
+
+### What the model sees vs. doesn't see
+
+- Sees: cash deducted, confirmation of spend.
+- Does NOT see: goodwill, multiplier, decay rate, sqrt scaling, variability range. Must infer effectiveness from observed sales over subsequent days.
+
+### Same-day aggregation
+
+Multiple `purchase_advertising` calls in the same day **stack in dollar amount**, then the diminishing-returns curve is applied once at end of day. So ten $20 calls behaves identically to one $200 call. This prevents exploiting square-root concavity by splitting one budget into many small calls.
+
+### Parameters (current shipped values)
+
+| Parameter | Value | What it controls |
+|---|---:|---|
+| `sqrt_scale` | 10.0 | How quickly goodwill saturates per dollar spent |
+| `mult_cap` | 0.20 | Maximum demand boost — caps multiplier at 1.20× |
+| `decay` | 0.80 | 20% of goodwill bleeds off each morning (~7-day half-life) |
+| `var_lo`, `var_hi` | 0.9, 1.1 | ±10% variability on goodwill earned |
+
+Calibration sweep showed marginal ROI hits zero around $200 spend; peak total profit at $200 is roughly $1,900 over a 30-day window. See `experiments/calibrate_advertising.py` to re-tune.
+
+## Tools available to the model
+
+| Tool | Purpose |
+|---|---|
+| `check_inventory()` | View stock + expiration dates |
+| `check_morning_prices()` | Today's supply prices |
+| `get_historical_supply_costs()` | Past supply prices for trend analysis |
+| `order_supplies(cups, lemons, sugar, water)` | Buy supplies |
+| `set_price(price)` | Today's lemonade price |
+| `set_operating_hours(open_hour, close_hour)` | Today's hours |
+| `purchase_automation()` | One-time labor elimination ($1,000) |
+| `purchase_advertising(spend)` | Buy ads; uncertain ROI, diminishing returns, same-day aggregation |
+| `open_for_business()` | Commit decisions; required to start the day |
+
+The model does not have direct access to the demand function, hourly multipliers, or noise distribution — these must be inferred from observed sales.
+
+## What the model sees each day
+
+- Day number, total days
+- Cash on hand
+- Profit yesterday
+- Automation status (Yes/No)
+- Historical performance table (every prior day's price, profit, customers served, hours, stockouts)
+
+## Other roadmap items (not yet designed)
+
+- Marketing features beyond simple ad spend (brand investment, promotions, quality upgrades).
+- Multi-location, capital structure (debt, buybacks), vertical integration, seasonality — paper roadmap.
+
+See `TODO.md` for the full v1.0/v2.0 backlog.

--- a/lemonade_bench_v1/experiments/calibrate_advertising.py
+++ b/lemonade_bench_v1/experiments/calibrate_advertising.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Calibration script for the proposed advertising mechanic.
+
+Runs Monte Carlo trials of "spend $X on ads on day 1, run optimal-price game
+for N days" and reports the distribution of cumulative profit deltas vs a
+no-ad baseline. Use this to tune (sqrt_scale, mult_cap, decay, variability)
+before locking the design in.
+
+Example:
+    .venv/bin/python experiments/calibrate_advertising.py
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import statistics
+from dataclasses import dataclass
+
+# --- Baseline game constants (mirror business_game.py) ---
+HOURLY_MULTIPLIERS: dict[int, float] = {
+    6: 0.3,
+    7: 0.5,
+    8: 0.7,
+    9: 0.8,
+    10: 1.0,
+    11: 1.2,
+    12: 1.5,
+    13: 1.3,
+    14: 0.9,
+    15: 0.8,
+    16: 0.9,
+    17: 1.1,
+    18: 1.0,
+    19: 0.7,
+    20: 0.4,
+}
+PRICE = 2.69
+INGREDIENT_COST = 0.37
+HOURS_OPEN = list(range(6, 21))  # 6am–8pm, 15 hours
+HOUR_VARIATION = 0.10  # ±10% noise per hour, matches DemandModel default
+DEMAND_INTERCEPT = 50
+DEMAND_SLOPE = 10
+
+
+@dataclass
+class AdParams:
+    """Parameters controlling the advertising mechanic."""
+
+    sqrt_scale: float = 10.0  # goodwill = sqrt(spend/100) * sqrt_scale * variability
+    mult_cap: float = 0.20  # max multiplier above 1.0 (saturation cap)
+    decay: float = 0.80  # daily decay of goodwill
+    var_lo: float = 0.90  # variability range on goodwill earned
+    var_hi: float = 1.10
+
+
+def baseline_daily_customers() -> int:
+    """One realization of a day's customer count at optimal price + hours."""
+    base = max(0, DEMAND_INTERCEPT - DEMAND_SLOPE * PRICE)
+    total = 0
+    for hour in HOURS_OPEN:
+        noise = random.uniform(1 - HOUR_VARIATION, 1 + HOUR_VARIATION)
+        total += round(base * HOURLY_MULTIPLIERS[hour] * noise)
+    return total
+
+
+def simulate_one_trial(spend: float, params: AdParams, n_days: int) -> float:
+    """Return cumulative profit delta (with-ad − without-ad − spend)."""
+    goodwill = (
+        math.sqrt(spend / 100)
+        * params.sqrt_scale
+        * random.uniform(
+            params.var_lo,
+            params.var_hi,
+        )
+    )
+    profit_delta = 0.0
+    margin_per_cup = PRICE - INGREDIENT_COST
+    for _ in range(n_days):
+        baseline_cust = baseline_daily_customers()
+        mult = 1 + params.mult_cap * (1 - math.exp(-goodwill))
+        ad_cust = round(baseline_cust * mult)
+        # Operating costs (labor + utilities) are identical with or without
+        # ads, so they cancel when computing the delta.
+        profit_delta += (ad_cust - baseline_cust) * margin_per_cup
+        goodwill *= params.decay
+    return profit_delta - spend
+
+
+def simulate_spend(
+    spend: float,
+    params: AdParams,
+    n_days: int = 30,
+    n_trials: int = 5000,
+) -> dict[str, float]:
+    """Run n_trials of an ad campaign, summarize the profit-delta distribution."""
+    deltas = [simulate_one_trial(spend, params, n_days) for _ in range(n_trials)]
+    deltas.sort()
+    return {
+        "spend": spend,
+        "mean": statistics.mean(deltas),
+        "median": deltas[n_trials // 2],
+        "std": statistics.stdev(deltas),
+        "p10": deltas[int(n_trials * 0.10)],
+        "p90": deltas[int(n_trials * 0.90)],
+        "pct_profitable": sum(1 for d in deltas if d > 0) / n_trials,
+        "mean_roi": statistics.mean(deltas) / spend if spend > 0 else 0.0,
+    }
+
+
+def print_sweep(spends: list[float], params: AdParams, n_days: int) -> None:
+    """Print a calibration table across spend amounts."""
+    print(
+        f"\nAd calibration — n_days={n_days}, params="
+        f"sqrt_scale={params.sqrt_scale}, mult_cap={params.mult_cap}, "
+        f"decay={params.decay}, var=({params.var_lo},{params.var_hi})",
+    )
+    print(
+        f"{'spend':>8} {'mean Δ':>10} {'median Δ':>10} {'p10':>10} {'p90':>10} "
+        f"{'std':>8} {'%profit':>8} {'ROI':>7}",
+    )
+    print("-" * 80)
+    for spend in spends:
+        r = simulate_spend(spend, params, n_days=n_days)
+        print(
+            f"${r['spend']:>7.0f} "
+            f"{r['mean']:>+10.0f} "
+            f"{r['median']:>+10.0f} "
+            f"{r['p10']:>+10.0f} "
+            f"{r['p90']:>+10.0f} "
+            f"{r['std']:>8.0f} "
+            f"{r['pct_profitable']:>8.1%} "
+            f"{r['mean_roi']:>+7.2f}x",
+        )
+
+
+def main() -> None:
+    spends = [50, 100, 200, 500, 1000, 2500, 5000, 10000]
+
+    print("=" * 80)
+    print("CURRENT PROPOSAL")
+    print("=" * 80)
+    print_sweep(spends, AdParams(), n_days=30)
+
+    print("\n" + "=" * 80)
+    print("WEAKER MEAN BOOST (mult_cap=0.10)")
+    print("=" * 80)
+    print_sweep(spends, AdParams(mult_cap=0.10), n_days=30)
+
+    print("\n" + "=" * 80)
+    print("HIGHER VARIANCE (var=0.5–1.5)")
+    print("=" * 80)
+    print_sweep(spends, AdParams(var_lo=0.5, var_hi=1.5), n_days=30)
+
+    print("\n" + "=" * 80)
+    print("FASTER DECAY (decay=0.6)")
+    print("=" * 80)
+    print_sweep(spends, AdParams(decay=0.6), n_days=30)
+
+    print("\n" + "=" * 80)
+    print("HEAVY DIMINISHING RETURNS (sqrt_scale=5, mult_cap=0.10)")
+    print("=" * 80)
+    print_sweep(spends, AdParams(sqrt_scale=5.0, mult_cap=0.10), n_days=30)
+
+
+if __name__ == "__main__":
+    main()

--- a/lemonade_bench_v1/experiments/run_benchmark.py
+++ b/lemonade_bench_v1/experiments/run_benchmark.py
@@ -130,6 +130,7 @@ def run_single_game(
                     "expired_items": day_info["expired_items"],
                     "supply_costs": supply_costs,
                     "has_automation": game.has_automation,
+                    "ad_goodwill": game.ad_goodwill,
                 },
             )
 
@@ -171,6 +172,7 @@ def run_single_game(
                     "open_hour": game.open_hour,
                     "close_hour": game.close_hour,
                     "has_automation": game.has_automation,
+                    "ad_goodwill": game.ad_goodwill,
                 },
                 total_attempts=turn_result.get("attempts", 1),
             )

--- a/lemonade_bench_v1/src/lemonadebench/business_game.py
+++ b/lemonade_bench_v1/src/lemonadebench/business_game.py
@@ -1,5 +1,6 @@
 """Main game engine for the lemonade stand business simulation."""
 
+import math
 import random
 from collections import deque
 from decimal import ROUND_HALF_UP, Decimal, getcontext
@@ -18,6 +19,13 @@ DEFAULT_UTILITIES_COST_PER_HOUR = to_decimal("2.00")
 DEFAULT_AUTOMATION_COST = to_decimal("1000.00")
 DEFAULT_TOTAL_DAYS = 100
 LEMONADE_RECIPE = {"cups": 1, "lemons": 1, "sugar": 1, "water": 1}
+
+# Advertising parameters (hidden from the model — must be inferred from sales).
+DEFAULT_AD_SQRT_SCALE = 10.0
+DEFAULT_AD_MULT_CAP = 0.20
+DEFAULT_AD_DECAY = 0.80
+DEFAULT_AD_VAR_LO = 0.90
+DEFAULT_AD_VAR_HI = 1.10
 
 
 class Inventory:
@@ -328,6 +336,11 @@ class BusinessGame:
         labor_cost_per_hour: Decimal | float = DEFAULT_LABOR_COST_PER_HOUR,
         utilities_cost_per_hour: Decimal | float = DEFAULT_UTILITIES_COST_PER_HOUR,
         automation_cost: Decimal | float = DEFAULT_AUTOMATION_COST,
+        ad_sqrt_scale: float = DEFAULT_AD_SQRT_SCALE,
+        ad_mult_cap: float = DEFAULT_AD_MULT_CAP,
+        ad_decay: float = DEFAULT_AD_DECAY,
+        ad_var_lo: float = DEFAULT_AD_VAR_LO,
+        ad_var_hi: float = DEFAULT_AD_VAR_HI,
     ) -> None:
         """Initialize the business game.
 
@@ -340,6 +353,10 @@ class BusinessGame:
                 of automation.
             automation_cost: One-time cost to eliminate labor for the rest
                 of the game.
+            ad_sqrt_scale: Goodwill earned per sqrt(spend / 100).
+            ad_mult_cap: Maximum demand multiplier above 1.0 (saturation cap).
+            ad_decay: Daily multiplicative decay applied to goodwill.
+            ad_var_lo, ad_var_hi: Uniform range on goodwill earned per campaign.
 
         """
         self.total_days = days
@@ -352,6 +369,15 @@ class BusinessGame:
         )
         self.automation_cost = to_decimal(automation_cost).quantize(TWOPLACES)
         self.has_automation: bool = False
+
+        # Advertising state — all hidden from the model
+        self.ad_sqrt_scale = ad_sqrt_scale
+        self.ad_mult_cap = ad_mult_cap
+        self.ad_decay = ad_decay
+        self.ad_var_lo = ad_var_lo
+        self.ad_var_hi = ad_var_hi
+        self.ad_goodwill: float = 0.0
+        self.today_ad_spend: Decimal = to_decimal(0).quantize(TWOPLACES)
 
         # Initialize components
         self.inventory = Inventory()
@@ -399,6 +425,10 @@ class BusinessGame:
         self.supply_cost_history.append(
             {"day": self.current_day, **self.today_supply_costs},
         )
+
+        # Decay yesterday's advertising goodwill, reset today's spend bucket
+        self.ad_goodwill *= self.ad_decay
+        self.today_ad_spend = to_decimal(0).quantize(TWOPLACES)
 
         # Reset daily state
         self.price_set = False
@@ -596,6 +626,45 @@ class BusinessGame:
             ),
         }
 
+    def purchase_advertising(self, spend: int) -> dict[str, Any]:
+        """Spend cash on an ad campaign for today.
+
+        Multiple calls on the same day aggregate (their dollar amounts sum
+        before the diminishing-returns curve is applied).
+
+        Args:
+            spend: Dollars to spend (positive integer).
+
+        Returns:
+            Dict with success status; effectiveness must be inferred from
+            subsequent customer counts (no internals exposed).
+
+        """
+        if spend <= 0:
+            return {
+                "success": False,
+                "error": "Advertising spend must be a positive integer.",
+            }
+        spend_dec = to_decimal(spend).quantize(TWOPLACES)
+        if self.cash < spend_dec:
+            return {
+                "success": False,
+                "error": (
+                    f"Insufficient cash. Need ${spend_dec:.2f}, have ${self.cash:.2f}."
+                ),
+            }
+
+        self.cash = (self.cash - spend_dec).quantize(TWOPLACES)
+        self.today_ad_spend = (self.today_ad_spend + spend_dec).quantize(TWOPLACES)
+        return {
+            "success": True,
+            "message": (
+                f"Spent ${spend_dec:.2f} on advertising today "
+                f"(today's total ad spend: ${self.today_ad_spend:.2f}). "
+                f"Cash remaining: ${self.cash:.2f}."
+            ),
+        }
+
     def simulate_day(self) -> dict[str, Any]:
         """Simulate the day's business after all decisions are made.
 
@@ -603,12 +672,29 @@ class BusinessGame:
             Day's results
 
         """
-        # Calculate customers for each hour
+        # Roll today's ad spend into goodwill (sqrt scaling + variability) so
+        # ads bought this morning affect today's demand.
+        ad_spend_today = self.today_ad_spend
+        if ad_spend_today > 0:
+            self.ad_goodwill += (
+                math.sqrt(float(ad_spend_today) / 100)
+                * self.ad_sqrt_scale
+                * random.uniform(self.ad_var_lo, self.ad_var_hi)
+            )
+
+        # Demand multiplier saturates at (1 + ad_mult_cap).
+        ad_multiplier = 1 + self.ad_mult_cap * (1 - math.exp(-self.ad_goodwill))
+
+        # Calculate customers for each hour, scaled by today's ad multiplier
         hourly_customers = self.demand_model.calculate_daily_customers(
             float(self.price),
             self.open_hour,
             self.close_hour,
         )
+        if ad_multiplier != 1.0:
+            hourly_customers = {
+                h: round(c * ad_multiplier) for h, c in hourly_customers.items()
+            }
 
         # Simulate sales hour by hour
         hourly_sales = {}
@@ -671,6 +757,7 @@ class BusinessGame:
             "profit": profit,
             "cash": self.cash,
             "hourly_sales": hourly_sales,
+            "ad_spend": ad_spend_today,
         }
 
         # Store in history
@@ -727,6 +814,8 @@ BUSINESS MECHANICS:
 (${labor:.2f} labor + ${utilities:.2f} utilities)
 - Automation: pay ${auto_cost:.2f} once to permanently eliminate the labor \
 portion. Utilities still apply.
+- Advertising: spend cash on ads to boost demand. Effects are temporary, \
+have diminishing returns, and ROI is uncertain — you'll need to experiment.
 - Recipe: 1 lemonade = 1 cup + 1 lemon + 1 sugar + 1 water (all required)
 - You can only sell lemonade if you have ALL ingredients in stock
 
@@ -742,7 +831,7 @@ INVENTORY MANAGEMENT:
 DAILY WORKFLOW:
 1. Morning: Check inventory and supply prices
 2. Decisions: Order supplies, set price and operating hours, optionally \
-purchase automation
+purchase automation, optionally buy advertising
 3. IMPORTANT: Call open_for_business() after setting price and hours
 4. Evening: Review profit/loss and customer data
 
@@ -755,6 +844,8 @@ AVAILABLE TOOLS:
 - set_operating_hours(open_hour, close_hour): Set today's operating hours
 - purchase_automation(): One-time purchase that eliminates labor cost \
 for the rest of the game
+- purchase_advertising(spend): Buy ads (positive integer dollars). \
+Affects today's demand. Multiple calls in a single day stack in dollar amount.
 - open_for_business(): REQUIRED - Open the stand after setting price and hours
 
 IMPORTANT: You MUST call open_for_business() after setting your price and \
@@ -805,17 +896,22 @@ Automation: {automation_status}
             return ""
 
         table = "\nHISTORICAL PERFORMANCE:\n"
-        table += "Day | Price | Profit     | Customers | Hours Open | Ran Out\n"
-        table += "----|-------|------------|-----------|------------|--------\n"
+        table += (
+            "Day | Price | Profit     | Customers | Hours Open | Ad Spend | Ran Out\n"
+        )
+        table += (
+            "----|-------|------------|-----------|------------|----------|--------\n"
+        )
 
         # Show ALL days
         for day in self.history:
             ran_out = "Yes" if day["customers_lost"] > 0 else "No"
             hours = f"{day['open_hour']}-{day['close_hour']}"
+            ad_spend = day.get("ad_spend", to_decimal(0))
             table += (
                 f"{day['day']:3} | ${day['price']:5.2f} | "
                 f"${day['profit']:9.2f} | {day['customers_served']:9} | "
-                f"{hours:^10} | {ran_out:^7}\n"
+                f"{hours:^10} | ${ad_spend:7.2f} | {ran_out:^7}\n"
             )
 
         return table

--- a/lemonade_bench_v1/src/lemonadebench/deepseek_player.py
+++ b/lemonade_bench_v1/src/lemonadebench/deepseek_player.py
@@ -24,6 +24,7 @@ from .tool_schemas import (
     GetHistoricalSupplyCostsParams,
     OpenForBusinessParams,
     OrderSuppliesParams,
+    PurchaseAdvertisingParams,
     PurchaseAutomationParams,
     SetOperatingHoursParams,
     SetPriceParams,
@@ -154,6 +155,15 @@ class DeepSeekPlayer:
                 PurchaseAutomationParams,
             ),
             self._build_tool(
+                "purchase_advertising",
+                (
+                    "Spend cash on advertising today. Multiple calls in a "
+                    "single day stack in dollar amount. Effects are "
+                    "temporary; ROI is uncertain — experiment to learn."
+                ),
+                PurchaseAdvertisingParams,
+            ),
+            self._build_tool(
                 "open_for_business",
                 "Open the stand for business (must set price and hours first)",
                 OpenForBusinessParams,
@@ -202,6 +212,8 @@ class DeepSeekPlayer:
                 result = game.get_historical_supply_costs()
             elif tool_name == "purchase_automation":
                 result = game.purchase_automation()
+            elif tool_name == "purchase_advertising":
+                result = game.purchase_advertising(**args)
             elif tool_name == "open_for_business":
                 result = game.open_for_business()
             else:

--- a/lemonade_bench_v1/src/lemonadebench/openai_player.py
+++ b/lemonade_bench_v1/src/lemonadebench/openai_player.py
@@ -17,6 +17,7 @@ from .tool_schemas import (
     GetHistoricalSupplyCostsParams,
     OpenForBusinessParams,
     OrderSuppliesParams,
+    PurchaseAdvertisingParams,
     PurchaseAutomationParams,
     SetOperatingHoursParams,
     SetPriceParams,
@@ -161,6 +162,15 @@ class OpenAIPlayer:
                 PurchaseAutomationParams,
             ),
             self._build_tool(
+                "purchase_advertising",
+                (
+                    "Spend cash on advertising today. Multiple calls in a "
+                    "single day stack in dollar amount. Effects are "
+                    "temporary; ROI is uncertain — experiment to learn."
+                ),
+                PurchaseAdvertisingParams,
+            ),
+            self._build_tool(
                 "open_for_business",
                 "Open the stand for business (must set price and hours first)",
                 OpenForBusinessParams,
@@ -231,6 +241,8 @@ class OpenAIPlayer:
                 result = game.get_historical_supply_costs()
             elif tool_name == "purchase_automation":
                 result = game.purchase_automation()
+            elif tool_name == "purchase_advertising":
+                result = game.purchase_advertising(**args)
             elif tool_name == "open_for_business":
                 result = game.open_for_business()
             else:

--- a/lemonade_bench_v1/src/lemonadebench/tool_schemas.py
+++ b/lemonade_bench_v1/src/lemonadebench/tool_schemas.py
@@ -52,3 +52,12 @@ class OpenForBusinessParams(BaseModel):
 
 class PurchaseAutomationParams(BaseModel):
     """Parameters for the purchase_automation tool (no parameters)."""
+
+
+class PurchaseAdvertisingParams(BaseModel):
+    """Parameters for the purchase_advertising tool."""
+
+    spend: int = Field(
+        gt=0,
+        description="Dollars to spend on advertising today (positive integer)",
+    )

--- a/lemonade_bench_v1/tests/test_business_game.py
+++ b/lemonade_bench_v1/tests/test_business_game.py
@@ -290,6 +290,7 @@ class TestBusinessGame:
         assert "You run a lemonade stand" in system_prompt
         assert "100 days" in system_prompt
         assert "purchase_automation" in system_prompt
+        assert "purchase_advertising" in system_prompt
         # Pin the cost numbers so any constant change must update the prompt
         assert "$3.00 labor" in system_prompt
         assert "$2.00 utilities" in system_prompt
@@ -371,6 +372,56 @@ class TestBusinessGame:
         assert "insufficient" in result["error"].lower()
         assert game.has_automation is False
         assert game.cash == Decimal(500)
+
+    def test_purchase_advertising_success(self):
+        """Buying ads deducts cash and accumulates today's spend."""
+        game = BusinessGame()
+        game.start_new_day()
+        result = game.purchase_advertising(100)
+        assert result["success"] is True
+        assert game.cash == Decimal(900)
+        assert game.today_ad_spend == Decimal(100)
+
+    def test_purchase_advertising_aggregates_same_day(self):
+        """Multiple same-day calls sum into today_ad_spend."""
+        game = BusinessGame()
+        game.start_new_day()
+        game.purchase_advertising(50)
+        game.purchase_advertising(75)
+        assert game.today_ad_spend == Decimal(125)
+        assert game.cash == Decimal(875)
+
+    def test_purchase_advertising_rejects_zero_or_negative(self):
+        """Ads must be a positive integer."""
+        game = BusinessGame()
+        game.start_new_day()
+        result = game.purchase_advertising(0)
+        assert result["success"] is False
+
+    def test_purchase_advertising_insufficient_cash(self):
+        """Without enough cash, buying ads fails and state is unchanged."""
+        game = BusinessGame(starting_cash=50)
+        game.start_new_day()
+        result = game.purchase_advertising(100)
+        assert result["success"] is False
+        assert game.cash == Decimal(50)
+        assert game.today_ad_spend == Decimal(0)
+
+    def test_simulate_day_records_ad_spend_and_resets(self):
+        """After a day with ads, the day_result includes ad_spend; tomorrow resets."""
+        game = BusinessGame()
+        game.start_new_day()
+        game.order_supplies(cups=300, lemons=300, sugar=300, water=300)
+        game.set_price(2.0)
+        game.set_operating_hours(10, 18)
+        game.purchase_advertising(100)
+        result = game.simulate_day()
+        assert result["ad_spend"] == Decimal(100)
+
+        game.start_new_day()
+        # Goodwill carries (decayed) into next day; today's spend bucket resets.
+        assert game.today_ad_spend == Decimal(0)
+        assert game.ad_goodwill > 0
 
     def test_simulate_day_after_automation_drops_labor(self):
         """After automation, operating cost charges only utilities ($2/hr)."""


### PR DESCRIPTION
## Summary
New \`purchase_advertising(spend)\` tool. Spend cash today → boost demand today (and decaying for several days after). Hidden mechanics; uncertain ROI.

## Mechanic
- **Spend → goodwill**: \`goodwill += sqrt(spend/100) * 10 * Uniform(0.9, 1.1)\`
- **Daily demand multiplier**: \`1 + 0.20 * (1 - exp(-goodwill))\` — saturates at 1.20×
- **Daily decay**: \`goodwill *= 0.80\` each morning (~7-day half-life)
- **Same-day aggregation**: multiple calls on day N sum in dollar amount before sqrt scaling. Prevents exploiting concavity by splitting one budget.
- **Same-day effect**: ads bought this morning affect today's demand.

## Visibility
- Model sees: cash deducted, confirmation, new \`Ad Spend\` column in the history table
- Hidden: goodwill, multiplier, decay rate, sqrt scaling, variability

## Calibration target (current)
- Marginal ROI hits zero around \$200 spend — confirmed by \`experiments/calibrate_advertising.py\`
- Peak total profit ~\$1,900 over 30 days at \$200 spend

## Live smoke test
deepseek-v4-flash, 5 days. Model spent \$20–\$40/day for days 2–5. Goodwill grew 4.3 → 15.7 (approaching saturation). Customers 100 → 200 → 302 → 249 → 299. Cash \$1K → \$3,159.

## Test plan
- [x] 47/47 pytest pass (5 new advertising cases)
- [x] Lint clean for files touched
- [x] Live DeepSeek smoke test
- [x] Same-day aggregation verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)