### PR TITLE
v1: ads — per-campaign tracking, hard 7-day cutoff

### DIFF
--- a/lemonade_bench_v1/MECHANICS.md
+++ b/lemonade_bench_v1/MECHANICS.md
@@ -105,8 +105,8 @@ A `purchase_advertising(spend)` tool that lets the model spend cash on ads, boos
 2. **Goodwill → demand multiplier** each day:
    $$\text{multiplier} = 1 + c \cdot (1 - e^{-\text{goodwill}})$$
    where $c$ is `mult_cap` — the maximum boost. Saturates at $1+c$ no matter how much goodwill accumulates.
-3. **Daily decay**: each morning, $\text{goodwill} \mathrel{*}= 0.80$ (20% bleeds off).
-4. **Effect on demand**: that day's customer counts (after the existing per-hour noise) are scaled by the multiplier.
+3. **Per-campaign decay + 7-day cutoff**: each campaign at age $d$ contributes $\text{goodwill} \cdot 0.80^d$ to current goodwill. Once $d \ge 7$, the campaign drops out completely (zero contribution).
+4. **Effect on demand**: that day's customer counts (after the existing per-hour noise) are scaled by the multiplier derived from total active goodwill across all live campaigns.
 
 ### What the model sees vs. doesn't see
 
@@ -117,13 +117,20 @@ A `purchase_advertising(spend)` tool that lets the model spend cash on ads, boos
 
 Multiple `purchase_advertising` calls in the same day **stack in dollar amount**, then the diminishing-returns curve is applied once at end of day. So ten $20 calls behaves identically to one $200 call. This prevents exploiting square-root concavity by splitting one budget into many small calls.
 
+### 7-day campaign lifetime
+
+Each $purchase_advertising$ call creates a new campaign tracked individually. A campaign at age $d$ days contributes $\text{goodwill} \cdot \text{decay}^d$ to current total goodwill, but **stops contributing entirely once age reaches 7 days**. So a single ad spend has zero residual effect by day 8.
+
+Multiple campaigns from different days sum their contributions into total goodwill, which then maps through the saturation curve to today's multiplier.
+
 ### Parameters (current shipped values)
 
 | Parameter | Value | What it controls |
 |---|---:|---|
 | `sqrt_scale` | 10.0 | How quickly goodwill saturates per dollar spent |
 | `mult_cap` | 0.20 | Maximum demand boost — caps multiplier at 1.20× |
-| `decay` | 0.80 | 20% of goodwill bleeds off each morning (~7-day half-life) |
+| `decay` | 0.80 | Per-campaign daily decay (geometric until cutoff) |
+| `lifetime_days` | 7 | Each campaign contributes 0 once age reaches this |
 | `var_lo`, `var_hi` | 0.9, 1.1 | ±10% variability on goodwill earned |
 
 Calibration sweep showed marginal ROI hits zero around $200 spend; peak total profit at $200 is roughly $1,900 over a 30-day window. See `experiments/calibrate_advertising.py` to re-tune.

--- a/lemonade_bench_v1/src/lemonadebench/business_game.py
+++ b/lemonade_bench_v1/src/lemonadebench/business_game.py
@@ -26,6 +26,7 @@ DEFAULT_AD_MULT_CAP = 0.20
 DEFAULT_AD_DECAY = 0.80
 DEFAULT_AD_VAR_LO = 0.90
 DEFAULT_AD_VAR_HI = 1.10
+DEFAULT_AD_LIFETIME_DAYS = 7  # campaign contributes 0 once age >= this
 
 
 class Inventory:
@@ -341,6 +342,7 @@ class BusinessGame:
         ad_decay: float = DEFAULT_AD_DECAY,
         ad_var_lo: float = DEFAULT_AD_VAR_LO,
         ad_var_hi: float = DEFAULT_AD_VAR_HI,
+        ad_lifetime_days: int = DEFAULT_AD_LIFETIME_DAYS,
     ) -> None:
         """Initialize the business game.
 
@@ -355,8 +357,10 @@ class BusinessGame:
                 of the game.
             ad_sqrt_scale: Goodwill earned per sqrt(spend / 100).
             ad_mult_cap: Maximum demand multiplier above 1.0 (saturation cap).
-            ad_decay: Daily multiplicative decay applied to goodwill.
+            ad_decay: Daily multiplicative decay applied to a campaign's goodwill.
             ad_var_lo, ad_var_hi: Uniform range on goodwill earned per campaign.
+            ad_lifetime_days: Each campaign contributes 0 once its age reaches
+                this many days (hard cutoff on top of the multiplicative decay).
 
         """
         self.total_days = days
@@ -370,13 +374,17 @@ class BusinessGame:
         self.automation_cost = to_decimal(automation_cost).quantize(TWOPLACES)
         self.has_automation: bool = False
 
-        # Advertising state — all hidden from the model
+        # Advertising state — all hidden from the model.
+        # ad_campaigns is a list of (day_purchased, goodwill_at_purchase).
+        # Each campaign contributes goodwill * decay^age to current goodwill,
+        # and stops contributing once its age reaches ad_lifetime_days.
         self.ad_sqrt_scale = ad_sqrt_scale
         self.ad_mult_cap = ad_mult_cap
         self.ad_decay = ad_decay
         self.ad_var_lo = ad_var_lo
         self.ad_var_hi = ad_var_hi
-        self.ad_goodwill: float = 0.0
+        self.ad_lifetime_days = ad_lifetime_days
+        self.ad_campaigns: list[tuple[int, float]] = []
         self.today_ad_spend: Decimal = to_decimal(0).quantize(TWOPLACES)
 
         # Initialize components
@@ -400,6 +408,19 @@ class BusinessGame:
 
         # Recipe for making lemonade
         self.recipe = LEMONADE_RECIPE.copy()
+
+    @property
+    def ad_goodwill(self) -> float:
+        """Total active advertising goodwill (sum across live campaigns).
+
+        Each campaign at age d contributes goodwill * decay^d, and is dropped
+        once age >= ad_lifetime_days.
+        """
+        return sum(
+            goodwill * (self.ad_decay ** (self.current_day - day))
+            for day, goodwill in self.ad_campaigns
+            if (self.current_day - day) < self.ad_lifetime_days
+        )
 
     def start_new_day(self) -> dict[str, Any]:
         """Start a new day: handle expiration, generate costs, reset state.
@@ -426,8 +447,8 @@ class BusinessGame:
             {"day": self.current_day, **self.today_supply_costs},
         )
 
-        # Decay yesterday's advertising goodwill, reset today's spend bucket
-        self.ad_goodwill *= self.ad_decay
+        # Reset today's ad-spend bucket. Goodwill from prior campaigns
+        # decays by age in simulate_day, no morning decay needed here.
         self.today_ad_spend = to_decimal(0).quantize(TWOPLACES)
 
         # Reset daily state
@@ -672,18 +693,27 @@ class BusinessGame:
             Day's results
 
         """
-        # Roll today's ad spend into goodwill (sqrt scaling + variability) so
-        # ads bought this morning affect today's demand.
+        # Roll today's ad spend into a fresh campaign (sqrt scaling +
+        # variability), then compute total active goodwill across campaigns
+        # within the lifetime window. Each campaign at age d contributes
+        # goodwill * decay^d, and contributes 0 once age >= lifetime.
         ad_spend_today = self.today_ad_spend
         if ad_spend_today > 0:
-            self.ad_goodwill += (
+            new_goodwill = (
                 math.sqrt(float(ad_spend_today) / 100)
                 * self.ad_sqrt_scale
                 * random.uniform(self.ad_var_lo, self.ad_var_hi)
             )
+            self.ad_campaigns.append((self.current_day, new_goodwill))
+
+        total_goodwill = sum(
+            goodwill * (self.ad_decay ** (self.current_day - day))
+            for day, goodwill in self.ad_campaigns
+            if (self.current_day - day) < self.ad_lifetime_days
+        )
 
         # Demand multiplier saturates at (1 + ad_mult_cap).
-        ad_multiplier = 1 + self.ad_mult_cap * (1 - math.exp(-self.ad_goodwill))
+        ad_multiplier = 1 + self.ad_mult_cap * (1 - math.exp(-total_goodwill))
 
         # Calculate customers for each hour, scaled by today's ad multiplier
         hourly_customers = self.demand_model.calculate_daily_customers(

--- a/lemonade_bench_v1/tests/test_business_game.py
+++ b/lemonade_bench_v1/tests/test_business_game.py
@@ -423,6 +423,34 @@ class TestBusinessGame:
         assert game.today_ad_spend == Decimal(0)
         assert game.ad_goodwill > 0
 
+    def test_advertising_zeroes_after_lifetime(self):
+        """A campaign contributes 0 goodwill once age == ad_lifetime_days."""
+        game = BusinessGame()  # lifetime=7
+        # Day 1: spend, run, goodwill should be > 0 right after.
+        game.start_new_day()
+        game.order_supplies(cups=300, lemons=300, sugar=300, water=300)
+        game.set_price(2.0)
+        game.set_operating_hours(10, 18)
+        game.purchase_advertising(200)
+        game.simulate_day()
+        assert game.ad_goodwill > 0
+
+        # Advance 6 more days without spending more — still within window
+        for _ in range(6):
+            game.start_new_day()
+            game.set_price(2.0)
+            game.set_operating_hours(10, 18)
+            game.simulate_day()
+        # Now age = 6, still active (just barely)
+        assert game.ad_goodwill > 0
+
+        # One more day: age = 7, campaign drops out, goodwill must be 0
+        game.start_new_day()
+        game.set_price(2.0)
+        game.set_operating_hours(10, 18)
+        game.simulate_day()
+        assert game.ad_goodwill == 0
+
     def test_simulate_day_after_automation_drops_labor(self):
         """After automation, operating cost charges only utilities ($2/hr)."""
         game = BusinessGame()


### PR DESCRIPTION
## Summary
A single ad spend now contributes **zero** demand boost by day 8. Previously the geometric decay never actually reached zero — after 7 days a \$200 spend still contributed ~21% of its original boost.

## Mechanic change
- Replace single \`ad_goodwill\` scalar with \`ad_campaigns: list[tuple[day, goodwill]]\` so each spend is tracked individually.
- A campaign at age \`d\` contributes \`goodwill * decay^d\`, but **drops out completely** once \`d >= 7\`.
- Total active goodwill = sum across live campaigns; saturation curve and multiplier work the same.
- Same-day aggregation, same-day effect, all hidden mechanics — unchanged.

## Why per-campaign vs single scalar
The behavior matters when multiple campaigns overlap. Single-scalar decay would smear them together and never bottom out; per-campaign tracking gives each spend a clean lifecycle.

## Test plan
- [x] 48/48 pytest pass (1 new test: \`test_advertising_zeroes_after_lifetime\` spends \$200 day 1, advances 7 days, asserts \`ad_goodwill == 0\`)
- [x] Lint clean for files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)